### PR TITLE
fix: migrate additional random UUIDs to time-based UUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Overview
 
 * Performance optimizations for the catalog request
+* Migrate additional random UUIDs to time-based UUIDs
 
 #### Compatibility
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -40,6 +40,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
 import org.jetbrains.annotations.NotNull;
@@ -49,7 +50,6 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static java.lang.String.format;
-import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.joining;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.CONSUMER;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.PROVIDER;
@@ -156,7 +156,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
             return ServiceResult.success(existingTransferProcess);
         }
         var process = TransferProcess.Builder.newInstance()
-                .id(randomUUID().toString())
+                .id(UuidGenerator.INSTANCE.generate().toString())
                 .protocol(message.getProtocol())
                 .correlationId(message.getConsumerPid())
                 .counterPartyAddress(message.getCallbackAddress())

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractagreement/ContractAgreementServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractagreement/ContractAgreementServiceImplTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.mockito.ArgumentMatchers.any;
@@ -109,7 +108,7 @@ class ContractAgreementServiceImplTest {
     private ContractNegotiation createContractNegotiation(String negotiationId) {
         return ContractNegotiation.Builder.newInstance()
                 .id(negotiationId)
-                .counterPartyId(randomUUID().toString())
+                .counterPartyId(UuidGenerator.INSTANCE.generate().toString())
                 .counterPartyAddress("address")
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
                         .uri("local://test")

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -55,6 +55,7 @@ import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
@@ -77,7 +78,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -372,7 +372,7 @@ class ContractNegotiationIntegrationTest {
     private ContractOffer getContractOffer() {
         return ContractOffer.Builder.newInstance()
                 .id(ContractOfferId.create("1", "test-asset-id").toString())
-                .assetId(randomUUID().toString())
+                .assetId(UuidGenerator.INSTANCE.generate().toString())
                 .policy(Policy.Builder.newInstance()
                         .type(PolicyType.CONTRACT)
                         .assigner("assigner")

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
@@ -36,6 +36,7 @@ import org.eclipse.edc.policy.model.Prohibition;
 import org.eclipse.edc.policy.model.Rule;
 import org.eclipse.edc.policy.model.XoneConstraint;
 import org.eclipse.edc.spi.agent.ParticipantIdMapper;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,7 +44,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Optional;
 
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
-import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
@@ -160,7 +160,7 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
             policy.getObligations().forEach(duty -> obligationsBuilder.add(duty.accept(this)));
 
             var builder = jsonFactory.createObjectBuilder()
-                    .add(ID, randomUUID().toString())
+                    .add(ID, UuidGenerator.INSTANCE.generate().toString())
                     .add(TYPE, getTypeAsString(policy.getType()))
                     .add(ODRL_PERMISSION_ATTRIBUTE, permissionsBuilder)
                     .add(ODRL_PROHIBITION_ATTRIBUTE, prohibitionsBuilder)

--- a/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSinkTest.java
+++ b/core/data-plane/data-plane-util/src/test/java/org/eclipse/edc/connector/dataplane/util/sink/ParallelSinkTest.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamFailure;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.telemetry.Telemetry;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static java.lang.String.format;
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,7 +47,7 @@ class ParallelSinkTest {
     private final InputStreamDataSource dataSource = new InputStreamDataSource(
             dataSourceName,
             new ByteArrayInputStream(dataSourceContent.getBytes()));
-    private final String dataFlowRequestId = randomUUID().toString();
+    private final String dataFlowRequestId = UuidGenerator.INSTANCE.generate().toString();
     FakeParallelSink fakeSink;
 
     @BeforeEach

--- a/docs/developer/fork/0.7.2.X.md
+++ b/docs/developer/fork/0.7.2.X.md
@@ -16,3 +16,11 @@ the separator should not be `File.separator` is it causes an error on windows wh
 Identical to [0.2.1.X.md](0.2.1.X.md#switch-to-uuidv7)'s UUID switch.
 
 ---
+
+## Catalog performance
+
+Changes to improve the performance of the catalog request
+* Stop re-compiling a regex on each use and eventually ttop relying on that regex
+* Add caching for frequently used `PathItem`s.
+
+---

--- a/docs/developer/fork/0.7.2.X.md
+++ b/docs/developer/fork/0.7.2.X.md
@@ -22,5 +22,12 @@ Identical to [0.2.1.X.md](0.2.1.X.md#switch-to-uuidv7)'s UUID switch.
 Changes to improve the performance of the catalog request
 * Stop re-compiling a regex on each use and eventually ttop relying on that regex
 * Add caching for frequently used `PathItem`s.
+* Avoid needless String formatting.
 
 ---
+
+## Force shutdown
+
+The EDC doesn't want to shutdown on its own, because of a few non-daemon threads.
+
+Changes were made to ask the executor that possesses those threads to shut down and if unsuccessful force the shutdown.

--- a/extensions/common/transaction/transaction-atomikos/src/test/java/org/eclipse/edc/transaction/atomikos/AtomikosTransactionExtensionTest.java
+++ b/extensions/common/transaction/transaction-atomikos/src/test/java/org/eclipse/edc/transaction/atomikos/AtomikosTransactionExtensionTest.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +28,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
 
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,7 +45,7 @@ class AtomikosTransactionExtensionTest {
     @Test
     void verifyEndToEndTransactions() {
         var extensionContext = mock(ServiceExtensionContext.class);
-        when(extensionContext.getRuntimeId()).thenReturn(randomUUID().toString());
+        when(extensionContext.getRuntimeId()).thenReturn(UuidGenerator.INSTANCE.generate().toString());
         when(extensionContext.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(AtomikosTransactionExtension.LOGGING, "false")));
 
         when(extensionContext.getConfig(isA(String.class))).thenAnswer(a -> JdbcTestFixtures.createDataSourceConfig());

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/BaseContractAgreementApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/BaseContractAgreementApiControllerTest.java
@@ -38,7 +38,6 @@ import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.util.Collections.emptyList;
-import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -251,7 +250,7 @@ public abstract class BaseContractAgreementApiControllerTest extends RestControl
     private ContractNegotiation.Builder createContractNegotiationBuilder(String negotiationId) {
         return ContractNegotiation.Builder.newInstance()
                 .id(negotiationId)
-                .counterPartyId(randomUUID().toString())
+                .counterPartyId(UuidGenerator.INSTANCE.generate().toString())
                 .counterPartyAddress("address")
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
                         .uri("local://test")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.validator.spi.ValidationResult;
@@ -40,7 +41,6 @@ import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
-import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
 import static org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.model.NegotiationState.NEGOTIATION_STATE_TYPE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand.TERMINATE_NEGOTIATION_TYPE;
@@ -332,7 +332,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
                         .counterPartyAddress("test-cb")
                         .contractOffer(ContractOffer.Builder.newInstance()
                                 .id("test-offer-id")
-                                .assetId(randomUUID().toString())
+                                .assetId(UuidGenerator.INSTANCE.generate().toString())
                                 .policy(Policy.Builder.newInstance().build())
                                 .build())
                         .build()));
@@ -459,7 +459,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
                 .id(negotiationId)
                 .consumerId("test-consumer")
                 .providerId("test-provider")
-                .assetId(randomUUID().toString())
+                .assetId(UuidGenerator.INSTANCE.generate().toString())
                 .policy(Policy.Builder.newInstance().build())
                 .build();
     }
@@ -467,7 +467,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
     private ContractNegotiation.Builder createContractNegotiationBuilder(String negotiationId) {
         return ContractNegotiation.Builder.newInstance()
                 .id(negotiationId)
-                .counterPartyId(randomUUID().toString())
+                .counterPartyId(UuidGenerator.INSTANCE.generate().toString())
                 .counterPartyAddress("address")
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
                         .uri("local://test")

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/controlplane/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/controlplane/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -60,7 +60,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.PROVISIONING_REQUESTED;
@@ -155,13 +154,13 @@ public class HttpProvisionerExtensionEndToEndTest {
                 .build();
 
         var contractOffer = ContractOffer.Builder.newInstance()
-                .id(randomUUID().toString())
-                .assetId(randomUUID().toString())
+                .id(UuidGenerator.INSTANCE.generate().toString())
+                .assetId(UuidGenerator.INSTANCE.generate().toString())
                 .policy(policy)
                 .build();
         return ContractNegotiation.Builder.newInstance()
-                .id(randomUUID().toString())
-                .counterPartyId(randomUUID().toString())
+                .id(UuidGenerator.INSTANCE.generate().toString())
+                .counterPartyId(UuidGenerator.INSTANCE.generate().toString())
                 .counterPartyAddress("test")
                 .protocol("test")
                 .contractAgreement(contractAgreement)
@@ -179,7 +178,7 @@ public class HttpProvisionerExtensionEndToEndTest {
 
     private TransferRequestMessage createTransferRequestMessage() {
         return TransferRequestMessage.Builder.newInstance()
-                .processId(randomUUID().toString())
+                .processId(UuidGenerator.INSTANCE.generate().toString())
                 .dataDestination(DataAddress.Builder.newInstance().type("test").build())
                 .protocol("any")
                 .counterPartyAddress("http://any")

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
@@ -16,11 +16,10 @@ package org.eclipse.edc.spi.types.domain.message;
 
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * A remote message that conveys state modifications of a process. These messages are idempotent.
@@ -159,7 +158,7 @@ public abstract class ProcessRemoteMessage implements RemoteMessage {
 
         public M build() {
             if (message.id == null) {
-                message.id = randomUUID().toString();
+                message.id = UuidGenerator.INSTANCE.generate().toString();
             }
             return message;
         }

--- a/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceCacheTestBase.java
+++ b/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceCacheTestBase.java
@@ -19,9 +19,9 @@ import org.eclipse.edc.junit.assertions.AbstractResultAssert;
 import org.eclipse.edc.spi.result.StoreFailure;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.junit.jupiter.api.Test;
 
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -34,7 +34,7 @@ public abstract class EndpointDataReferenceCacheTestBase {
         var tpId = "tp1";
         var assetId = "asset1";
         var dataAddress = dataAddress();
-        var entry = TestFunctions.edrEntry(assetId, randomUUID().toString(), tpId, randomUUID().toString());
+        var entry = TestFunctions.edrEntry(assetId, UuidGenerator.INSTANCE.generate().toString(), tpId, UuidGenerator.INSTANCE.generate().toString());
 
         getCache().put(entry.getTransferProcessId(), dataAddress);
 

--- a/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceEntryIndexTestBase.java
+++ b/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceEntryIndexTestBase.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.StoreFailure;
 import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,7 +33,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -46,7 +46,7 @@ public abstract class EndpointDataReferenceEntryIndexTestBase {
         var tpId = "tp1";
         var assetId = "asset1";
 
-        var entry = TestFunctions.edrEntry(assetId, randomUUID().toString(), tpId, randomUUID().toString());
+        var entry = TestFunctions.edrEntry(assetId, UuidGenerator.INSTANCE.generate().toString(), tpId, UuidGenerator.INSTANCE.generate().toString());
 
         getStore().save(entry);
 
@@ -62,14 +62,14 @@ public abstract class EndpointDataReferenceEntryIndexTestBase {
         var tpId = "tp1";
         var assetId = "asset1";
 
-        var entry = TestFunctions.edrEntry(assetId, randomUUID().toString(), tpId, randomUUID().toString());
+        var entry = TestFunctions.edrEntry(assetId, UuidGenerator.INSTANCE.generate().toString(), tpId, UuidGenerator.INSTANCE.generate().toString());
 
         getStore().save(entry);
 
         var dbEntry = getStore().findById(entry.getTransferProcessId());
         assertThat(dbEntry).isNotNull().usingRecursiveComparison().isEqualTo(entry);
 
-        entry = TestFunctions.edrEntry(assetId, randomUUID().toString(), tpId, randomUUID().toString());
+        entry = TestFunctions.edrEntry(assetId, UuidGenerator.INSTANCE.generate().toString(), tpId, UuidGenerator.INSTANCE.generate().toString());
         getStore().save(entry);
 
         dbEntry = getStore().findById(entry.getTransferProcessId());

--- a/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceStoreTestBase.java
+++ b/spi/common/edr-store-spi/src/testFixtures/java/org/eclipse/edc/edr/spi/store/EndpointDataReferenceStoreTestBase.java
@@ -19,12 +19,12 @@ import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 import org.junit.jupiter.api.Test;
 
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.GENERAL_ERROR;
 
@@ -39,7 +39,7 @@ public abstract class EndpointDataReferenceStoreTestBase {
         var tpId = "tp1";
         var assetId = "asset1";
 
-        var entry = TestFunctions.edrEntry(assetId, randomUUID().toString(), tpId, randomUUID().toString());
+        var entry = TestFunctions.edrEntry(assetId, UuidGenerator.INSTANCE.generate().toString(), tpId, UuidGenerator.INSTANCE.generate().toString());
 
         getStore().save(entry, TestFunctions.dataAddress());
 

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Catalog.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Catalog.java
@@ -17,13 +17,12 @@ package org.eclipse.edc.connector.controlplane.catalog.spi;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * Entity representing a Catalog
@@ -116,7 +115,7 @@ public class Catalog {
 
         public Catalog build() {
             if (catalog.id == null) {
-                catalog.id = randomUUID().toString();
+                catalog.id = UuidGenerator.INSTANCE.generate().toString();
             }
 
             return catalog;

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DataService.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DataService.java
@@ -17,10 +17,9 @@ package org.eclipse.edc.connector.controlplane.catalog.spi;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 
 import java.util.Objects;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * Models the DataService class of the DCAT spec. A DataService is defined as a collection
@@ -102,7 +101,7 @@ public class DataService {
 
         public DataService build() {
             if (dataService.id == null) {
-                dataService.id = randomUUID().toString();
+                dataService.id = UuidGenerator.INSTANCE.generate().toString();
             }
 
             return dataService;

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Dataset.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/Dataset.java
@@ -19,13 +19,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.uuid.UuidGenerator;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.UUID.randomUUID;
 
 /**
  * Models the Dataset class of the DCAT spec. A Dataset is defined as a collection of data
@@ -128,7 +127,7 @@ public class Dataset {
 
         public Dataset build() {
             if (dataset.id == null) {
-                dataset.id = randomUUID().toString();
+                dataset.id = UuidGenerator.INSTANCE.generate().toString();
             }
 
             return dataset;

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -38,7 +38,6 @@ import java.util.Set;
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
@@ -185,7 +184,7 @@ public class ContractNegotiationApiEndToEndTest {
             return ContractNegotiation.Builder.newInstance()
                     .id(negotiationId)
                     .correlationId(negotiationId)
-                    .counterPartyId(randomUUID().toString())
+                    .counterPartyId(UuidGenerator.INSTANCE.generate().toString())
                     .counterPartyAddress("http://counter-party/address")
                     .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
                             .uri("local://test")
@@ -199,16 +198,16 @@ public class ContractNegotiationApiEndToEndTest {
         private ContractOffer.Builder contractOfferBuilder() {
             return ContractOffer.Builder.newInstance()
                     .id("test-offer-id")
-                    .assetId(randomUUID().toString())
+                    .assetId(UuidGenerator.INSTANCE.generate().toString())
                     .policy(Policy.Builder.newInstance().build());
         }
 
         private ContractAgreement createContractAgreement(String negotiationId) {
             return ContractAgreement.Builder.newInstance()
                     .id(negotiationId)
-                    .assetId(randomUUID().toString())
-                    .consumerId(randomUUID() + "-consumer")
-                    .providerId(randomUUID() + "-provider")
+                    .assetId(UuidGenerator.INSTANCE.generate().toString())
+                    .consumerId(UuidGenerator.INSTANCE.generate() + "-consumer")
+                    .providerId(UuidGenerator.INSTANCE.generate() + "-provider")
                     .policy(Policy.Builder.newInstance().build())
                     .build();
         }


### PR DESCRIPTION
Some java.util.UUIDs -> Time-based UUID changes were missed during the 0.2.1 -> 0.7.2 migration.

```[tasklist]
### Checklist
- [x] CHANGELOG.md
- [x] docs/developer/fork/VERSION.md
- [x] I have performed a **self-review**
```
