### PR TITLE
fix: pin github action hashes

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -16,8 +16,8 @@ jobs:
     name: 'Update snapshot version'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: sovity/core-edc-github/.github/actions/bump-version@0.11.1_2025-03-10_1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: sovity/core-edc-github/.github/actions/bump-version@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
         name: Bump version
         with:
           target_branch: ${{ inputs.target_branch }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   Prepare-Release:
-    uses: sovity/core-edc-github/.github/workflows/core-prepare-release.yml@0.11.1_2025-03-10_1
+    uses: sovity/core-edc-github/.github/workflows/core-prepare-release.yml@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
     secrets: inherit
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/publish-autodoc.yml
+++ b/.github/workflows/publish-autodoc.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   publish:
-    uses: sovity/core-edc-github/.github/workflows/publish-autodoc.yml@0.11.1_2025-03-10_1
+    uses: sovity/core-edc-github/.github/workflows/publish-autodoc.yml@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
     secrets: inherit
     with:
       version: ${{ github.event.inputs.version }}

--- a/.github/workflows/publish-context.yaml
+++ b/.github/workflows/publish-context.yaml
@@ -35,13 +35,13 @@ jobs:
       contents: write
       pages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: copy contexts into public folder
         run: |
           mkdir -p public/context
           cp extensions/common/json-ld/src/main/resources/document/management-context-v1.jsonld public/context/
       - name: deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public

--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   publish:
-    uses: sovity/core-edc-github/.github/workflows/publish-openapi-ui.yml@0.11.1_2025-03-10_1
+    uses: sovity/core-edc-github/.github/workflows/publish-openapi-ui.yml@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
     secrets: inherit

--- a/.github/workflows/scan-pull-request.yaml
+++ b/.github/workflows/scan-pull-request.yaml
@@ -11,6 +11,6 @@ concurrency:
 
 jobs:
   trigger-workflow:
-    uses: sovity/core-edc-github/.github/workflows/scan-pull-request.yml@0.11.1_2025-03-10_1
+    uses: sovity/core-edc-github/.github/workflows/scan-pull-request.yml@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
     secrets:
       envGH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   trigger-workflow:
-    uses: sovity/core-edc-github/.github/workflows/stale-bot.yml@0.11.1_2025-03-10_1
+    uses: sovity/core-edc-github/.github/workflows/stale-bot.yml@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
     secrets:
       envGH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger_snapshot.yml
+++ b/.github/workflows/trigger_snapshot.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   Publish-Snapshot:
     # This workflow will abort if the required secrets don't exist
-    uses: sovity/core-edc-github/.github/workflows/publish-snapshot.yml@0.11.1_2025-03-10_1
+    uses: sovity/core-edc-github/.github/workflows/publish-snapshot.yml@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
     secrets: inherit
 
   Publish-Dependencies:
-    uses: sovity/core-edc-github/.github/workflows/publish-dependencies.yml@0.11.1_2025-03-10_1
+    uses: sovity/core-edc-github/.github/workflows/publish-dependencies.yml@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
     secrets: inherit

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -23,30 +23,30 @@ env:
 
 jobs:
 #  CodeQL:
-#    uses: sovity/core-edc-github/.github/workflows/codeql-analysis.yml@0.11.1_2025-03-10_1
+#    uses: sovity/core-edc-github/.github/workflows/codeql-analysis.yml@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
 #    secrets: inherit
 
   Checkstyle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: sovity/core-edc-github/.github/actions/setup-build@0.11.1_2025-03-10_1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: sovity/core-edc-github/.github/actions/setup-build@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
       - name: Run Checkstyle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleTestFixtures
 
   Javadoc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: sovity/core-edc-github/.github/actions/setup-build@0.11.1_2025-03-10_1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: sovity/core-edc-github/.github/actions/setup-build@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
       - name: Run Javadoc
         run: ./gradlew javadoc
 
   Unit-Tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: sovity/core-edc-github/.github/actions/setup-build@0.11.1_2025-03-10_1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: sovity/core-edc-github/.github/actions/setup-build@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
       - name: Run unit tests
         run: ./gradlew test
 
@@ -62,32 +62,32 @@ jobs:
           POSTGRES_PASSWORD: password
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: sovity/core-edc-github/.github/actions/setup-build@0.11.1_2025-03-10_1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: sovity/core-edc-github/.github/actions/setup-build@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
       - name: Postgresql Tests
         run: ./gradlew test -DincludeTags="PostgresqlIntegrationTest"
 
   End-To-End-Tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: sovity/core-edc-github/.github/actions/setup-build@0.11.1_2025-03-10_1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: sovity/core-edc-github/.github/actions/setup-build@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
       - name: End to End Integration Tests
         run: ./gradlew test -DincludeTags="EndToEndTest"
 
   Component-Tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: sovity/core-edc-github/.github/actions/setup-build@0.11.1_2025-03-10_1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: sovity/core-edc-github/.github/actions/setup-build@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
       - name: Component Tests
         run: ./gradlew test -DincludeTags="ComponentTest"
 
   API-Tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: sovity/core-edc-github/.github/actions/setup-build@0.11.1_2025-03-10_1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: sovity/core-edc-github/.github/actions/setup-build@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
       - name: Component Tests
         run: ./gradlew test -DincludeTags="ApiTest"
 
@@ -98,7 +98,7 @@ jobs:
 
 #  Verify-OpenApi:
 #    if: github.event_name == 'pull_request'
-#    uses: sovity/core-edc-github/.github/workflows/verify-openapi.yml@0.11.1_2025-03-10_1
+#    uses: sovity/core-edc-github/.github/workflows/verify-openapi.yml@2a8d5ee91db61fa80792b75cd9f821179a17e683 #0.11.1_2025-03-10
 #    secrets: inherit
 
   Publish-Artifacts:
@@ -116,7 +116,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: "Gradle: Publish to Production"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Same change as #84, for `sovity/0.11.1`.

All GitHub Actions are pinned to an immutable commit SHA. Third-party actions carry a version comment; the `sovity/core-edc-github` references point at [`2a8d5ee`](https://github.com/sovity/core-edc-github/commit/2a8d5ee91db61fa80792b75cd9f821179a17e683) on `pinned/0.11.1_2025-03-10` instead of the mutable tag `0.11.1_2025-03-10_3`.

That commit is the counterpart to what `pinned/0.14.0_2025-08-21` got: `core-edc-github` no longer references its own composite actions through a tag. Composite actions use relative paths, and reusable workflows check the repo out at `github.job_workflow_sha` into `.reusable-actions`. Without it, pinning here would be cosmetic, since the pinned workflows would still pull their actions from a moving tag.

Supersedes #76, which only pinned the third-party actions.